### PR TITLE
Add Express backend with Prisma schema and seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ View your app in AI Studio: https://ai.studio/apps/drive/1NksvyaEmdqRcALjlGF4Kjm
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Backend API (server)
+
+The repository now includes a Node.js + TypeScript + Express backend in [`server/`](server/).
+
+1. Install dependencies: `cd server && npm install`
+2. Configure the database connection in [`server/.env`](server/.env). By default it targets a local PostgreSQL instance named `photolens`.
+3. Generate the Prisma client and apply the schema: `npx prisma generate` then `npx prisma migrate dev`.
+4. Seed the database with the mock data used in the UI: `npm run seed`.
+5. Start the API server: `npm run dev` (or `npm run start` after building with `npm run build`).
+
+The seed script reuses the fixtures defined in [`services/mockData.ts`](services/mockData.ts) so that the backend reflects the same initial dataset as the front-end mock data.

--- a/server/.env
+++ b/server/.env
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/photolens?schema=public"
+PORT=4000

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "photolens-server",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "prisma:deploy": "prisma migrate deploy",
+    "seed": "ts-node src/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.11.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "http-errors": "^2.0.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/http-errors": "^2.0.4",
+    "@types/node": "^20.11.17",
+    "prisma": "^5.11.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,0 +1,220 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  Owner
+  Admin
+  Photographer
+  Editor
+  Finance
+}
+
+enum StaffStatus {
+  Active
+  Invited
+  Inactive
+}
+
+enum BookingStatus {
+  Pending
+  Confirmed
+  Completed
+  Cancelled
+}
+
+enum InvoiceStatus {
+  Paid
+  Overdue
+  Sent
+}
+
+enum JobPriority {
+  Low
+  Normal
+  High
+  Urgent
+}
+
+model Client {
+  id             String        @id
+  name           String
+  email          String        @unique
+  phone          String?
+  avatarUrl      String?
+  joinDate       DateTime
+  totalBookings  Int           @default(0)
+  totalSpent     Decimal       @default(0) @db.Decimal(12, 2)
+  notes          String?
+  financialStatus String?
+  bookings       Booking[]
+  invoices       Invoice[]
+  editingJobs    EditingJob[]
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+}
+
+model Staff {
+  id                   String      @id
+  name                 String
+  email                String      @unique
+  avatarUrl            String?
+  role                 UserRole
+  status               StaffStatus
+  lastLogin            DateTime?
+  photographerBookings Booking[]   @relation("PhotographerBookings")
+  editingJobs          EditingJob[] @relation("EditorAssignments")
+  recordedPayments     Payment[]   @relation("PaymentRecorder")
+  createdAt            DateTime    @default(now())
+  updatedAt            DateTime    @updatedAt
+}
+
+model SessionCategory {
+  id        String           @id
+  name      String
+  packages  SessionPackage[]
+  bookings  Booking[]
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+}
+
+model SessionPackage {
+  id           String          @id
+  categoryId   String
+  category     SessionCategory @relation(fields: [categoryId], references: [id])
+  name         String
+  price        Decimal         @db.Decimal(10, 2)
+  inclusions   String[]
+  bookings     Booking[]
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+}
+
+model Booking {
+  id                 String          @id
+  clientId           String
+  client             Client          @relation(fields: [clientId], references: [id])
+  clientName         String
+  clientAvatarUrl    String?
+  sessionCategoryId  String
+  sessionCategory    SessionCategory @relation(fields: [sessionCategoryId], references: [id])
+  sessionPackageId   String
+  sessionPackage     SessionPackage  @relation(fields: [sessionPackageId], references: [id])
+  sessionType        String
+  photographerId     String?
+  photographer       Staff?          @relation("PhotographerBookings", fields: [photographerId], references: [id])
+  photographerName   String?
+  date               DateTime
+  status             BookingStatus
+  notes              String?
+  location           String?
+  photoSelections    Json?
+  editingJobs        EditingJob[]
+  expenses           Expense[]
+  invoice            Invoice?
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+}
+
+model Invoice {
+  id               String         @id
+  bookingId        String?        @unique
+  booking          Booking?       @relation(fields: [bookingId], references: [id])
+  clientId         String
+  client           Client         @relation(fields: [clientId], references: [id])
+  clientName       String
+  clientAvatarUrl  String?
+  amount           Decimal        @db.Decimal(12, 2)
+  amountPaid       Decimal        @default(0) @db.Decimal(12, 2)
+  issueDate        DateTime?
+  dueDate          DateTime
+  status           InvoiceStatus
+  lastReminderSent DateTime?
+  items            InvoiceItem[]
+  payments         Payment[]
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+}
+
+model InvoiceItem {
+  id          String   @id
+  invoiceId   String
+  invoice     Invoice  @relation(fields: [invoiceId], references: [id])
+  description String
+  quantity    Int
+  price       Decimal  @db.Decimal(10, 2)
+}
+
+model PaymentAccount {
+  id       String    @id
+  name     String
+  type     String
+  details  String?
+  payments Payment[]
+  expenses Expense[]
+  createdAt DateTime @default(now())
+}
+
+model Payment {
+  id              String    @id
+  invoiceId       String
+  invoice         Invoice   @relation(fields: [invoiceId], references: [id])
+  date            DateTime
+  amount          Decimal   @db.Decimal(12, 2)
+  accountId       String
+  account         PaymentAccount @relation(fields: [accountId], references: [id])
+  methodNotes     String?
+  recordedById    String?
+  recordedBy      Staff?    @relation("PaymentRecorder", fields: [recordedById], references: [id])
+  recordedByName  String?
+  createdAt       DateTime  @default(now())
+}
+
+model EditingStatus {
+  id        String       @id
+  name      String
+  color     String
+  jobs      EditingJob[]
+}
+
+model EditingJob {
+  id                String        @id
+  bookingId         String
+  booking           Booking       @relation(fields: [bookingId], references: [id])
+  clientId          String
+  client            Client        @relation(fields: [clientId], references: [id])
+  clientName        String
+  editorId          String?
+  editor            Staff?        @relation("EditorAssignments", fields: [editorId], references: [id])
+  editorName        String?
+  editorAvatarUrl   String?
+  statusId          String
+  status            EditingStatus @relation(fields: [statusId], references: [id])
+  uploadDate        DateTime
+  driveFolderUrl    String?
+  photographerNotes String?
+  priority          JobPriority   @default(Normal)
+  revisionCount     Int           @default(0)
+  revisionNotes     Json?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+}
+
+model Expense {
+  id          String         @id
+  category    String
+  description String
+  amount      Decimal        @db.Decimal(12, 2)
+  date        DateTime
+  accountId   String
+  account     PaymentAccount @relation(fields: [accountId], references: [id])
+  bookingId   String?
+  booking     Booking?       @relation(fields: [bookingId], references: [id])
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,55 @@
+import express from 'express';
+import cors from 'cors';
+import createError from 'http-errors';
+import {
+  bookingRouter,
+  clientRouter,
+  editingJobRouter,
+  editingStatusRouter,
+  expenseRouter,
+  invoiceRouter,
+  paymentAccountRouter,
+  sessionCategoryRouter,
+  sessionPackageRouter,
+  staffRouter,
+} from './modules';
+
+export const createApp = () => {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  app.use('/api/clients', clientRouter);
+  app.use('/api/staff', staffRouter);
+  app.use('/api/session-categories', sessionCategoryRouter);
+  app.use('/api/session-packages', sessionPackageRouter);
+  app.use('/api/payment-accounts', paymentAccountRouter);
+  app.use('/api/expenses', expenseRouter);
+  app.use('/api/editing-statuses', editingStatusRouter);
+  app.use('/api/editing-jobs', editingJobRouter);
+  app.use('/api/bookings', bookingRouter);
+  app.use('/api/invoices', invoiceRouter);
+
+  app.use((_req, _res, next) => {
+    next(new createError.NotFound('Route not found'));
+  });
+
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    if (err.name === 'ZodError') {
+      res.status(400).json({ message: 'Validation failed', details: err.errors });
+      return;
+    }
+
+    const status = err.status || 500;
+    res.status(status).json({
+      message: err.message || 'Internal Server Error',
+    });
+  });
+
+  return app;
+};

--- a/server/src/lib/prisma.ts
+++ b/server/src/lib/prisma.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/server/src/modules/bookings/booking.repository.ts
+++ b/server/src/modules/bookings/booking.repository.ts
@@ -1,0 +1,59 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const bookingRepository = {
+  findAll: () =>
+    prisma.booking.findMany({
+      include: {
+        client: true,
+        sessionCategory: true,
+        sessionPackage: true,
+        photographer: true,
+        invoice: { include: { items: true, payments: true } },
+        editingJobs: true,
+      },
+      orderBy: { date: 'desc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.booking.findUnique({
+      where: { id },
+      include: {
+        client: true,
+        sessionCategory: true,
+        sessionPackage: true,
+        photographer: true,
+        invoice: { include: { items: true, payments: true } },
+        editingJobs: true,
+      },
+    }),
+
+  create: (data: Prisma.BookingCreateInput) =>
+    prisma.booking.create({
+      data,
+      include: {
+        client: true,
+        sessionCategory: true,
+        sessionPackage: true,
+        photographer: true,
+        invoice: { include: { items: true, payments: true } },
+        editingJobs: true,
+      },
+    }),
+
+  update: (id: string, data: Prisma.BookingUpdateInput) =>
+    prisma.booking.update({
+      where: { id },
+      data,
+      include: {
+        client: true,
+        sessionCategory: true,
+        sessionPackage: true,
+        photographer: true,
+        invoice: { include: { items: true, payments: true } },
+        editingJobs: true,
+      },
+    }),
+
+  delete: (id: string) => prisma.booking.delete({ where: { id } }),
+};

--- a/server/src/modules/bookings/booking.router.ts
+++ b/server/src/modules/bookings/booking.router.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import { bookingService } from './booking.service';
+import { bookingSchema, bookingUpdateSchema } from './booking.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const bookings = await bookingService.list();
+    res.json(bookings);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const booking = await bookingService.getById(req.params.id);
+    res.json(booking);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = bookingSchema.parse(req.body);
+    const booking = await bookingService.create(payload);
+    res.status(201).json(booking);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = bookingUpdateSchema.parse(req.body);
+    const booking = await bookingService.update(req.params.id, payload);
+    res.json(booking);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await bookingService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/bookings/booking.service.ts
+++ b/server/src/modules/bookings/booking.service.ts
@@ -1,0 +1,110 @@
+import { BookingStatus, Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { clientRepository } from '../clients/client.repository';
+import { editingJobService } from '../editing-jobs';
+import { bookingRepository } from './booking.repository';
+
+export interface BookingInput {
+  id?: string;
+  clientId: string;
+  clientName: string;
+  clientAvatarUrl?: string | null;
+  sessionCategoryId: string;
+  sessionPackageId: string;
+  sessionType: string;
+  photographerId?: string | null;
+  photographerName?: string | null;
+  date: Date;
+  status: BookingStatus;
+  notes?: string | null;
+  location?: string | null;
+  photoSelections?: unknown;
+}
+
+export const bookingService = {
+  list() {
+    return bookingRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const booking = await bookingRepository.findById(id);
+    if (!booking) {
+      throw new createError.NotFound(`Booking ${id} not found`);
+    }
+    return booking;
+  },
+
+  async create(payload: BookingInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.BookingCreateInput = {
+      id,
+      client: { connect: { id: payload.clientId } },
+      clientName: payload.clientName,
+      clientAvatarUrl: payload.clientAvatarUrl ?? undefined,
+      sessionCategory: { connect: { id: payload.sessionCategoryId } },
+      sessionPackage: { connect: { id: payload.sessionPackageId } },
+      sessionType: payload.sessionType,
+      photographer: payload.photographerId
+        ? { connect: { id: payload.photographerId } }
+        : undefined,
+      photographerName: payload.photographerName ?? undefined,
+      date: payload.date,
+      status: payload.status,
+      notes: payload.notes ?? undefined,
+      location: payload.location ?? undefined,
+      photoSelections: payload.photoSelections,
+    };
+
+    const booking = await bookingRepository.create(data);
+    await clientRepository.updateStats(payload.clientId);
+    if (booking.status === BookingStatus.Completed) {
+      await editingJobService.ensureForCompletedBooking(booking.id);
+    }
+    return bookingRepository.findById(booking.id);
+  },
+
+  async update(id: string, payload: Partial<BookingInput>) {
+    const existing = await bookingService.getById(id);
+    const nextStatus = payload.status ?? existing.status;
+
+    const data: Prisma.BookingUpdateInput = {
+      client: payload.clientId ? { connect: { id: payload.clientId } } : undefined,
+      clientName: payload.clientName,
+      clientAvatarUrl: payload.clientAvatarUrl,
+      sessionCategory: payload.sessionCategoryId
+        ? { connect: { id: payload.sessionCategoryId } }
+        : undefined,
+      sessionPackage: payload.sessionPackageId
+        ? { connect: { id: payload.sessionPackageId } }
+        : undefined,
+      sessionType: payload.sessionType,
+      photographer: payload.photographerId
+        ? { connect: { id: payload.photographerId } }
+        : payload.photographerId === null
+        ? { disconnect: true }
+        : undefined,
+      photographerName: payload.photographerName,
+      date: payload.date,
+      status: payload.status,
+      notes: payload.notes,
+      location: payload.location,
+      photoSelections: payload.photoSelections,
+    };
+
+    const booking = await bookingRepository.update(id, data);
+    await clientRepository.updateStats(booking.clientId);
+
+    if (nextStatus === BookingStatus.Completed && existing.status !== BookingStatus.Completed) {
+      await editingJobService.ensureForCompletedBooking(booking.id);
+    }
+
+    return bookingRepository.findById(id);
+  },
+
+  async remove(id: string) {
+    const booking = await bookingService.getById(id);
+    await bookingRepository.delete(id);
+    await clientRepository.updateStats(booking.clientId);
+  },
+};

--- a/server/src/modules/bookings/booking.validation.ts
+++ b/server/src/modules/bookings/booking.validation.ts
@@ -1,0 +1,26 @@
+import { BookingStatus } from '@prisma/client';
+import { z } from 'zod';
+
+const photoSelectionSchema = z.object({
+  name: z.string(),
+  edited: z.boolean(),
+});
+
+export const bookingSchema = z.object({
+  id: z.string().optional(),
+  clientId: z.string(),
+  clientName: z.string().min(1),
+  clientAvatarUrl: z.string().url().optional(),
+  sessionCategoryId: z.string(),
+  sessionPackageId: z.string(),
+  sessionType: z.string().min(1),
+  photographerId: z.string().nullable().optional(),
+  photographerName: z.string().nullable().optional(),
+  date: z.coerce.date(),
+  status: z.nativeEnum(BookingStatus),
+  notes: z.string().nullable().optional(),
+  location: z.string().nullable().optional(),
+  photoSelections: z.array(photoSelectionSchema).optional(),
+});
+
+export const bookingUpdateSchema = bookingSchema.partial();

--- a/server/src/modules/bookings/index.ts
+++ b/server/src/modules/bookings/index.ts
@@ -1,0 +1,2 @@
+export { default as bookingRouter } from './booking.router';
+export { bookingService } from './booking.service';

--- a/server/src/modules/clients/client.repository.ts
+++ b/server/src/modules/clients/client.repository.ts
@@ -1,0 +1,51 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const clientRepository = {
+  findAll: () =>
+    prisma.client.findMany({
+      orderBy: { createdAt: 'desc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.client.findUnique({
+      where: { id },
+      include: {
+        bookings: true,
+        invoices: { include: { items: true, payments: true } },
+      },
+    }),
+
+  create: (data: Prisma.ClientCreateInput) => prisma.client.create({ data }),
+
+  update: (id: string, data: Prisma.ClientUpdateInput) =>
+    prisma.client.update({ where: { id }, data }),
+
+  delete: (id: string) => prisma.client.delete({ where: { id } }),
+
+  updateStats: async (id: string) => {
+    const [bookingSummary, invoiceSummary] = await Promise.all([
+      prisma.booking.aggregate({
+        where: { clientId: id, status: 'Completed' },
+        _count: { _all: true },
+      }),
+      prisma.invoice.aggregate({
+        where: { clientId: id, status: 'Paid' },
+        _sum: { amount: true },
+      }),
+    ]);
+
+    const totalBookings = bookingSummary._count._all ?? 0;
+    const totalSpent = invoiceSummary._sum.amount ?? new Prisma.Decimal(0);
+
+    const updatedClient = await prisma.client.update({
+      where: { id },
+      data: {
+        totalBookings,
+        totalSpent,
+      },
+    });
+
+    return updatedClient;
+  },
+};

--- a/server/src/modules/clients/client.router.ts
+++ b/server/src/modules/clients/client.router.ts
@@ -1,0 +1,66 @@
+import { Router } from 'express';
+import { clientService } from './client.service';
+import { createClientSchema, updateClientSchema } from './client.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const clients = await clientService.list();
+    res.json(clients);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const client = await clientService.getById(req.params.id);
+    res.json(client);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createClientSchema.parse(req.body);
+    const client = await clientService.create({
+      ...payload,
+      joinDate: payload.joinDate,
+    });
+    res.status(201).json(client);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateClientSchema.parse(req.body);
+    const client = await clientService.update(req.params.id, payload);
+    res.json(client);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await clientService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/refresh-stats', async (req, res, next) => {
+  try {
+    const client = await clientService.refreshStats(req.params.id);
+    res.json(client);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/clients/client.service.ts
+++ b/server/src/modules/clients/client.service.ts
@@ -1,0 +1,44 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { clientRepository } from './client.repository';
+
+export const clientService = {
+  async list() {
+    return clientRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const client = await clientRepository.findById(id);
+    if (!client) {
+      throw new createError.NotFound(`Client ${id} not found`);
+    }
+    return client;
+  },
+
+  async create(payload: Prisma.ClientCreateInput) {
+    const id = payload.id ?? randomUUID();
+    const client = await clientRepository.create({
+      ...payload,
+      id,
+    });
+    await clientRepository.updateStats(id);
+    return clientRepository.findById(id);
+  },
+
+  async update(id: string, payload: Prisma.ClientUpdateInput) {
+    await clientService.getById(id);
+    const client = await clientRepository.update(id, payload);
+    await clientRepository.updateStats(id);
+    return clientRepository.findById(client.id);
+  },
+
+  async remove(id: string) {
+    await clientService.getById(id);
+    await clientRepository.delete(id);
+  },
+
+  async refreshStats(id: string) {
+    return clientRepository.updateStats(id);
+  },
+};

--- a/server/src/modules/clients/client.validation.ts
+++ b/server/src/modules/clients/client.validation.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const clientBaseSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email(),
+  phone: z.string().min(3).optional(),
+  avatarUrl: z.string().url().optional(),
+  joinDate: z.coerce.date(),
+  notes: z.string().optional(),
+  financialStatus: z.string().optional(),
+});
+
+export const createClientSchema = clientBaseSchema;
+
+export const updateClientSchema = clientBaseSchema.partial();

--- a/server/src/modules/clients/index.ts
+++ b/server/src/modules/clients/index.ts
@@ -1,0 +1,1 @@
+export { default as clientRouter } from './client.router';

--- a/server/src/modules/editing-jobs/editingJob.repository.ts
+++ b/server/src/modules/editing-jobs/editingJob.repository.ts
@@ -1,0 +1,51 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const editingJobRepository = {
+  findAll: () =>
+    prisma.editingJob.findMany({
+      include: {
+        booking: true,
+        client: true,
+        editor: true,
+        status: true,
+      },
+      orderBy: { uploadDate: 'desc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.editingJob.findUnique({
+      where: { id },
+      include: {
+        booking: true,
+        client: true,
+        editor: true,
+        status: true,
+      },
+    }),
+
+  create: (data: Prisma.EditingJobCreateInput) =>
+    prisma.editingJob.create({
+      data,
+      include: {
+        booking: true,
+        client: true,
+        editor: true,
+        status: true,
+      },
+    }),
+
+  update: (id: string, data: Prisma.EditingJobUpdateInput) =>
+    prisma.editingJob.update({
+      where: { id },
+      data,
+      include: {
+        booking: true,
+        client: true,
+        editor: true,
+        status: true,
+      },
+    }),
+
+  delete: (id: string) => prisma.editingJob.delete({ where: { id } }),
+};

--- a/server/src/modules/editing-jobs/editingJob.router.ts
+++ b/server/src/modules/editing-jobs/editingJob.router.ts
@@ -1,0 +1,68 @@
+import { Router } from 'express';
+import { editingJobService } from './editingJob.service';
+import {
+  editingJobSchema,
+  editingJobStatusSchema,
+  editingJobUpdateSchema,
+} from './editingJob.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const jobs = await editingJobService.list();
+    res.json(jobs);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const job = await editingJobService.getById(req.params.id);
+    res.json(job);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = editingJobSchema.parse(req.body);
+    const job = await editingJobService.create(payload);
+    res.status(201).json(job);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = editingJobUpdateSchema.parse(req.body);
+    const job = await editingJobService.update(req.params.id, payload);
+    res.json(job);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.patch('/:id/status', async (req, res, next) => {
+  try {
+    const payload = editingJobStatusSchema.parse(req.body);
+    const job = await editingJobService.updateStatus(req.params.id, payload.statusId);
+    res.json(job);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await editingJobService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/editing-jobs/editingJob.service.ts
+++ b/server/src/modules/editing-jobs/editingJob.service.ts
@@ -1,0 +1,134 @@
+import { JobPriority, Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import prisma from '../../lib/prisma';
+import { editingJobRepository } from './editingJob.repository';
+
+export interface EditingJobInput {
+  id?: string;
+  bookingId: string;
+  clientId: string;
+  clientName: string;
+  editorId?: string | null;
+  editorName?: string | null;
+  editorAvatarUrl?: string | null;
+  statusId: string;
+  uploadDate: Date;
+  driveFolderUrl?: string | null;
+  photographerNotes?: string | null;
+  priority?: string;
+  revisionCount?: number;
+  revisionNotes?: unknown;
+}
+
+const mapPriority = (value?: string | null) => {
+  if (!value) return JobPriority.Normal;
+  const normalized = value.toLowerCase();
+  switch (normalized) {
+    case 'low':
+      return JobPriority.Low;
+    case 'high':
+      return JobPriority.High;
+    case 'urgent':
+      return JobPriority.Urgent;
+    default:
+      return JobPriority.Normal;
+  }
+};
+
+export const editingJobService = {
+  list() {
+    return editingJobRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const job = await editingJobRepository.findById(id);
+    if (!job) {
+      throw new createError.NotFound(`Editing job ${id} not found`);
+    }
+    return job;
+  },
+
+  create(payload: EditingJobInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.EditingJobCreateInput = {
+      id,
+      booking: { connect: { id: payload.bookingId } },
+      client: { connect: { id: payload.clientId } },
+      clientName: payload.clientName,
+      editor: payload.editorId ? { connect: { id: payload.editorId } } : undefined,
+      editorName: payload.editorName ?? undefined,
+      editorAvatarUrl: payload.editorAvatarUrl ?? undefined,
+      status: { connect: { id: payload.statusId } },
+      uploadDate: payload.uploadDate,
+      driveFolderUrl: payload.driveFolderUrl ?? undefined,
+      photographerNotes: payload.photographerNotes ?? undefined,
+      priority: mapPriority(payload.priority),
+      revisionCount: payload.revisionCount ?? 0,
+      revisionNotes: payload.revisionNotes,
+    };
+    return editingJobRepository.create(data);
+  },
+
+  async update(id: string, payload: Partial<EditingJobInput>) {
+    await editingJobService.getById(id);
+    const data: Prisma.EditingJobUpdateInput = {
+      editor: payload.editorId
+        ? { connect: { id: payload.editorId } }
+        : payload.editorId === null
+        ? { disconnect: true }
+        : undefined,
+      editorName: payload.editorName,
+      editorAvatarUrl: payload.editorAvatarUrl,
+      status: payload.statusId ? { connect: { id: payload.statusId } } : undefined,
+      uploadDate: payload.uploadDate,
+      driveFolderUrl: payload.driveFolderUrl,
+      photographerNotes: payload.photographerNotes,
+      priority: payload.priority ? mapPriority(payload.priority) : undefined,
+      revisionCount: payload.revisionCount,
+      revisionNotes: payload.revisionNotes,
+    };
+    return editingJobRepository.update(id, data);
+  },
+
+  async updateStatus(id: string, statusId: string) {
+    await editingJobService.getById(id);
+    return editingJobRepository.update(id, { status: { connect: { id: statusId } } });
+  },
+
+  async ensureForCompletedBooking(bookingId: string) {
+    const booking = await prisma.booking.findUnique({
+      where: { id: bookingId },
+      include: { client: true, editingJobs: true },
+    });
+    if (!booking || booking.status !== 'Completed') {
+      return null;
+    }
+
+    if (booking.editingJobs.length > 0) {
+      return booking.editingJobs[0];
+    }
+
+    const defaultStatus = await prisma.editingStatus.findFirst({
+      orderBy: { name: 'asc' },
+    });
+
+    if (!defaultStatus) {
+      throw new createError.BadRequest('No editing statuses configured');
+    }
+
+    return editingJobService.create({
+      bookingId: booking.id,
+      clientId: booking.clientId,
+      clientName: booking.clientName,
+      statusId: defaultStatus.id,
+      uploadDate: new Date(),
+      priority: 'Normal',
+    });
+  },
+
+  async remove(id: string) {
+    await editingJobService.getById(id);
+    await editingJobRepository.delete(id);
+  },
+};

--- a/server/src/modules/editing-jobs/editingJob.validation.ts
+++ b/server/src/modules/editing-jobs/editingJob.validation.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const editingJobSchema = z.object({
+  id: z.string().optional(),
+  bookingId: z.string(),
+  clientId: z.string(),
+  clientName: z.string(),
+  editorId: z.string().nullable().optional(),
+  editorName: z.string().nullable().optional(),
+  editorAvatarUrl: z.string().url().nullable().optional(),
+  statusId: z.string(),
+  uploadDate: z.coerce.date(),
+  driveFolderUrl: z.string().url().nullable().optional(),
+  photographerNotes: z.string().nullable().optional(),
+  priority: z.string().optional(),
+  revisionCount: z.number().int().nonnegative().optional(),
+  revisionNotes: z.unknown().optional(),
+});
+
+export const editingJobUpdateSchema = editingJobSchema.partial();
+
+export const editingJobStatusSchema = z.object({
+  statusId: z.string(),
+});

--- a/server/src/modules/editing-jobs/index.ts
+++ b/server/src/modules/editing-jobs/index.ts
@@ -1,0 +1,2 @@
+export { default as editingJobRouter } from './editingJob.router';
+export { editingJobService } from './editingJob.service';

--- a/server/src/modules/editing-statuses/editingStatus.repository.ts
+++ b/server/src/modules/editing-statuses/editingStatus.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const editingStatusRepository = {
+  findAll: () =>
+    prisma.editingStatus.findMany({
+      include: { jobs: true },
+      orderBy: { name: 'asc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.editingStatus.findUnique({
+      where: { id },
+      include: { jobs: true },
+    }),
+
+  create: (data: Prisma.EditingStatusCreateInput) =>
+    prisma.editingStatus.create({ data, include: { jobs: true } }),
+
+  update: (id: string, data: Prisma.EditingStatusUpdateInput) =>
+    prisma.editingStatus.update({
+      where: { id },
+      data,
+      include: { jobs: true },
+    }),
+
+  delete: (id: string) => prisma.editingStatus.delete({ where: { id } }),
+};

--- a/server/src/modules/editing-statuses/editingStatus.router.ts
+++ b/server/src/modules/editing-statuses/editingStatus.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { editingStatusService } from './editingStatus.service';
+import {
+  editingStatusSchema,
+  editingStatusUpdateSchema,
+} from './editingStatus.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const statuses = await editingStatusService.list();
+    res.json(statuses);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const status = await editingStatusService.getById(req.params.id);
+    res.json(status);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = editingStatusSchema.parse(req.body);
+    const status = await editingStatusService.create(payload);
+    res.status(201).json(status);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = editingStatusUpdateSchema.parse(req.body);
+    const status = await editingStatusService.update(req.params.id, payload);
+    res.json(status);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await editingStatusService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/editing-statuses/editingStatus.service.ts
+++ b/server/src/modules/editing-statuses/editingStatus.service.ts
@@ -1,0 +1,48 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { editingStatusRepository } from './editingStatus.repository';
+
+export interface EditingStatusInput {
+  id?: string;
+  name: string;
+  color: string;
+}
+
+export const editingStatusService = {
+  list() {
+    return editingStatusRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const status = await editingStatusRepository.findById(id);
+    if (!status) {
+      throw new createError.NotFound(`Editing status ${id} not found`);
+    }
+    return status;
+  },
+
+  create(payload: EditingStatusInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.EditingStatusCreateInput = {
+      id,
+      name: payload.name,
+      color: payload.color,
+    };
+    return editingStatusRepository.create(data);
+  },
+
+  async update(id: string, payload: Partial<EditingStatusInput>) {
+    await editingStatusService.getById(id);
+    const data: Prisma.EditingStatusUpdateInput = {
+      name: payload.name,
+      color: payload.color,
+    };
+    return editingStatusRepository.update(id, data);
+  },
+
+  async remove(id: string) {
+    await editingStatusService.getById(id);
+    await editingStatusRepository.delete(id);
+  },
+};

--- a/server/src/modules/editing-statuses/editingStatus.validation.ts
+++ b/server/src/modules/editing-statuses/editingStatus.validation.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const editingStatusSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  color: z.string().min(1),
+});
+
+export const editingStatusUpdateSchema = editingStatusSchema.partial();

--- a/server/src/modules/editing-statuses/index.ts
+++ b/server/src/modules/editing-statuses/index.ts
@@ -1,0 +1,1 @@
+export { default as editingStatusRouter } from './editingStatus.router';

--- a/server/src/modules/expenses/expense.repository.ts
+++ b/server/src/modules/expenses/expense.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const expenseRepository = {
+  findAll: () =>
+    prisma.expense.findMany({
+      include: { account: true, booking: true },
+      orderBy: { date: 'desc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.expense.findUnique({
+      where: { id },
+      include: { account: true, booking: true },
+    }),
+
+  create: (data: Prisma.ExpenseCreateInput) =>
+    prisma.expense.create({ data, include: { account: true, booking: true } }),
+
+  update: (id: string, data: Prisma.ExpenseUpdateInput) =>
+    prisma.expense.update({
+      where: { id },
+      data,
+      include: { account: true, booking: true },
+    }),
+
+  delete: (id: string) => prisma.expense.delete({ where: { id } }),
+};

--- a/server/src/modules/expenses/expense.router.ts
+++ b/server/src/modules/expenses/expense.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { expenseService } from './expense.service';
+import { expenseSchema, expenseUpdateSchema } from './expense.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const expenses = await expenseService.list();
+    res.json(expenses);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const expense = await expenseService.getById(req.params.id);
+    res.json(expense);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = expenseSchema.parse(req.body);
+    const expense = await expenseService.create({
+      ...payload,
+      date: payload.date,
+    });
+    res.status(201).json(expense);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = expenseUpdateSchema.parse(req.body);
+    const expense = await expenseService.update(req.params.id, payload);
+    res.json(expense);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await expenseService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/expenses/expense.service.ts
+++ b/server/src/modules/expenses/expense.service.ts
@@ -1,0 +1,64 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { expenseRepository } from './expense.repository';
+
+export interface ExpenseInput {
+  id?: string;
+  category: string;
+  description: string;
+  amount: number;
+  date: Date;
+  accountId: string;
+  bookingId?: string | null;
+}
+
+export const expenseService = {
+  list() {
+    return expenseRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const expense = await expenseRepository.findById(id);
+    if (!expense) {
+      throw new createError.NotFound(`Expense ${id} not found`);
+    }
+    return expense;
+  },
+
+  create(payload: ExpenseInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.ExpenseCreateInput = {
+      id,
+      category: payload.category,
+      description: payload.description,
+      amount: payload.amount,
+      date: payload.date,
+      account: { connect: { id: payload.accountId } },
+      booking: payload.bookingId ? { connect: { id: payload.bookingId } } : undefined,
+    };
+    return expenseRepository.create(data);
+  },
+
+  async update(id: string, payload: Partial<ExpenseInput>) {
+    await expenseService.getById(id);
+    const data: Prisma.ExpenseUpdateInput = {
+      category: payload.category,
+      description: payload.description,
+      amount: payload.amount,
+      date: payload.date,
+      account: payload.accountId ? { connect: { id: payload.accountId } } : undefined,
+      booking: payload.bookingId
+        ? { connect: { id: payload.bookingId } }
+        : payload.bookingId === null
+        ? { disconnect: true }
+        : undefined,
+    };
+    return expenseRepository.update(id, data);
+  },
+
+  async remove(id: string) {
+    await expenseService.getById(id);
+    await expenseRepository.delete(id);
+  },
+};

--- a/server/src/modules/expenses/expense.validation.ts
+++ b/server/src/modules/expenses/expense.validation.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const expenseSchema = z.object({
+  id: z.string().optional(),
+  category: z.string().min(1),
+  description: z.string().min(1),
+  amount: z.coerce.number(),
+  date: z.coerce.date(),
+  accountId: z.string(),
+  bookingId: z.string().nullable().optional(),
+});
+
+export const expenseUpdateSchema = expenseSchema.partial();

--- a/server/src/modules/expenses/index.ts
+++ b/server/src/modules/expenses/index.ts
@@ -1,0 +1,1 @@
+export { default as expenseRouter } from './expense.router';

--- a/server/src/modules/index.ts
+++ b/server/src/modules/index.ts
@@ -1,0 +1,10 @@
+export { clientRouter } from './clients';
+export { staffRouter } from './staff';
+export { sessionCategoryRouter } from './session-categories';
+export { sessionPackageRouter } from './session-packages';
+export { paymentAccountRouter } from './payment-accounts';
+export { expenseRouter } from './expenses';
+export { editingStatusRouter } from './editing-statuses';
+export { editingJobRouter } from './editing-jobs';
+export { bookingRouter } from './bookings';
+export { invoiceRouter } from './invoices';

--- a/server/src/modules/invoices/index.ts
+++ b/server/src/modules/invoices/index.ts
@@ -1,0 +1,2 @@
+export { default as invoiceRouter } from './invoice.router';
+export { invoiceService } from './invoice.service';

--- a/server/src/modules/invoices/invoice.repository.ts
+++ b/server/src/modules/invoices/invoice.repository.ts
@@ -1,0 +1,51 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const invoiceRepository = {
+  findAll: () =>
+    prisma.invoice.findMany({
+      include: {
+        client: true,
+        booking: true,
+        items: true,
+        payments: { include: { account: true, recordedBy: true } },
+      },
+      orderBy: { issueDate: 'desc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.invoice.findUnique({
+      where: { id },
+      include: {
+        client: true,
+        booking: true,
+        items: true,
+        payments: { include: { account: true, recordedBy: true } },
+      },
+    }),
+
+  create: (data: Prisma.InvoiceCreateInput) =>
+    prisma.invoice.create({
+      data,
+      include: {
+        client: true,
+        booking: true,
+        items: true,
+        payments: { include: { account: true, recordedBy: true } },
+      },
+    }),
+
+  update: (id: string, data: Prisma.InvoiceUpdateInput) =>
+    prisma.invoice.update({
+      where: { id },
+      data,
+      include: {
+        client: true,
+        booking: true,
+        items: true,
+        payments: { include: { account: true, recordedBy: true } },
+      },
+    }),
+
+  delete: (id: string) => prisma.invoice.delete({ where: { id } }),
+};

--- a/server/src/modules/invoices/invoice.router.ts
+++ b/server/src/modules/invoices/invoice.router.ts
@@ -1,0 +1,64 @@
+import { Router } from 'express';
+import { invoiceService } from './invoice.service';
+import { invoiceSchema, invoiceUpdateSchema, paymentSchema } from './invoice.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const invoices = await invoiceService.list();
+    res.json(invoices);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const invoice = await invoiceService.getById(req.params.id);
+    res.json(invoice);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = invoiceSchema.parse(req.body);
+    const invoice = await invoiceService.create(payload);
+    res.status(201).json(invoice);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = invoiceUpdateSchema.parse(req.body);
+    const invoice = await invoiceService.update(req.params.id, payload);
+    res.json(invoice);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/:id/payments', async (req, res, next) => {
+  try {
+    const payload = paymentSchema.parse(req.body);
+    const invoice = await invoiceService.addPayment(req.params.id, payload);
+    res.status(201).json(invoice);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await invoiceService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/invoices/invoice.service.ts
+++ b/server/src/modules/invoices/invoice.service.ts
@@ -1,0 +1,181 @@
+import { InvoiceStatus, Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import prisma from '../../lib/prisma';
+import { clientRepository } from '../clients/client.repository';
+import { invoiceRepository } from './invoice.repository';
+
+export interface InvoiceItemInput {
+  id?: string;
+  description: string;
+  quantity: number;
+  price: number;
+}
+
+export interface InvoiceInput {
+  id?: string;
+  bookingId?: string | null;
+  clientId: string;
+  clientName: string;
+  clientAvatarUrl?: string | null;
+  amount?: number;
+  issueDate?: Date | null;
+  dueDate: Date;
+  status: InvoiceStatus;
+  lastReminderSent?: Date | null;
+  items: InvoiceItemInput[];
+}
+
+export interface PaymentInput {
+  id?: string;
+  amount: number;
+  date: Date;
+  accountId: string;
+  methodNotes?: string | null;
+  recordedById?: string | null;
+  recordedByName?: string | null;
+}
+
+const calculateAmount = (items: InvoiceItemInput[]) =>
+  items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+
+const computeStatus = (invoice: { amount: Prisma.Decimal; amountPaid: Prisma.Decimal; dueDate: Date; status: InvoiceStatus; }) => {
+  const amount = Number(invoice.amount);
+  const paid = Number(invoice.amountPaid);
+  if (paid >= amount && amount > 0) {
+    return InvoiceStatus.Paid;
+  }
+  if (invoice.dueDate.getTime() < Date.now()) {
+    return InvoiceStatus.Overdue;
+  }
+  return InvoiceStatus.Sent;
+};
+
+export const invoiceService = {
+  list() {
+    return invoiceRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const invoice = await invoiceRepository.findById(id);
+    if (!invoice) {
+      throw new createError.NotFound(`Invoice ${id} not found`);
+    }
+    return invoice;
+  },
+
+  async create(payload: InvoiceInput) {
+    const id = payload.id ?? randomUUID();
+    const items = payload.items ?? [];
+    const amount = payload.amount ?? calculateAmount(items);
+    const data: Prisma.InvoiceCreateInput = {
+      id,
+      booking: payload.bookingId ? { connect: { id: payload.bookingId } } : undefined,
+      client: { connect: { id: payload.clientId } },
+      clientName: payload.clientName,
+      clientAvatarUrl: payload.clientAvatarUrl ?? undefined,
+      amount,
+      amountPaid: 0,
+      issueDate: payload.issueDate ?? undefined,
+      dueDate: payload.dueDate,
+      status: payload.status,
+      lastReminderSent: payload.lastReminderSent ?? undefined,
+      items: {
+        create: items.map((item) => ({
+          id: item.id ?? randomUUID(),
+          description: item.description,
+          quantity: item.quantity,
+          price: item.price,
+        })),
+      },
+    };
+
+    const invoice = await invoiceRepository.create(data);
+    await clientRepository.updateStats(payload.clientId);
+    return invoiceRepository.findById(invoice.id);
+  },
+
+  async update(id: string, payload: Partial<InvoiceInput>) {
+    const existing = await invoiceService.getById(id);
+    const items = payload.items;
+    const amount = payload.amount ?? (items ? calculateAmount(items) : undefined);
+
+    const data: Prisma.InvoiceUpdateInput = {
+      booking: payload.bookingId
+        ? { connect: { id: payload.bookingId } }
+        : payload.bookingId === null
+        ? { disconnect: true }
+        : undefined,
+      client: payload.clientId ? { connect: { id: payload.clientId } } : undefined,
+      clientName: payload.clientName,
+      clientAvatarUrl: payload.clientAvatarUrl,
+      amount,
+      issueDate: payload.issueDate,
+      dueDate: payload.dueDate,
+      status: payload.status,
+      lastReminderSent: payload.lastReminderSent,
+      items: items
+        ? {
+            deleteMany: {},
+            create: items.map((item) => ({
+              id: item.id ?? randomUUID(),
+              description: item.description,
+              quantity: item.quantity,
+              price: item.price,
+            })),
+          }
+        : undefined,
+    };
+
+    const invoice = await invoiceRepository.update(id, data);
+    await clientRepository.updateStats(invoice.clientId);
+    return invoiceRepository.findById(id);
+  },
+
+  async addPayment(id: string, payload: PaymentInput) {
+    const invoice = await invoiceService.getById(id);
+    const paymentId = payload.id ?? randomUUID();
+
+    await prisma.payment.create({
+      data: {
+        id: paymentId,
+        amount: payload.amount,
+        date: payload.date,
+        account: { connect: { id: payload.accountId } },
+        invoice: { connect: { id } },
+        methodNotes: payload.methodNotes ?? undefined,
+        recordedBy: payload.recordedById
+          ? { connect: { id: payload.recordedById } }
+          : undefined,
+        recordedByName: payload.recordedByName ?? undefined,
+      },
+    });
+
+    const payments = await prisma.payment.aggregate({
+      where: { invoiceId: id },
+      _sum: { amount: true },
+    });
+
+    const amountPaid = payments._sum.amount ?? new Prisma.Decimal(0);
+    const newStatus = computeStatus({
+      amount: invoice.amount,
+      amountPaid,
+      dueDate: invoice.dueDate,
+      status: invoice.status,
+    });
+
+    await prisma.invoice.update({
+      where: { id },
+      data: { amountPaid, status: newStatus },
+    });
+
+    await clientRepository.updateStats(invoice.clientId);
+    return invoiceRepository.findById(id);
+  },
+
+  async remove(id: string) {
+    const invoice = await invoiceService.getById(id);
+    await invoiceRepository.delete(id);
+    await clientRepository.updateStats(invoice.clientId);
+  },
+};

--- a/server/src/modules/invoices/invoice.validation.ts
+++ b/server/src/modules/invoices/invoice.validation.ts
@@ -1,0 +1,35 @@
+import { InvoiceStatus } from '@prisma/client';
+import { z } from 'zod';
+
+export const invoiceItemSchema = z.object({
+  id: z.string().optional(),
+  description: z.string().min(1),
+  quantity: z.coerce.number().int().positive(),
+  price: z.coerce.number().nonnegative(),
+});
+
+export const invoiceSchema = z.object({
+  id: z.string().optional(),
+  bookingId: z.string().nullable().optional(),
+  clientId: z.string(),
+  clientName: z.string().min(1),
+  clientAvatarUrl: z.string().url().nullable().optional(),
+  amount: z.coerce.number().optional(),
+  issueDate: z.coerce.date().nullable().optional(),
+  dueDate: z.coerce.date(),
+  status: z.nativeEnum(InvoiceStatus),
+  lastReminderSent: z.coerce.date().nullable().optional(),
+  items: z.array(invoiceItemSchema).min(1),
+});
+
+export const invoiceUpdateSchema = invoiceSchema.partial();
+
+export const paymentSchema = z.object({
+  id: z.string().optional(),
+  amount: z.coerce.number().positive(),
+  date: z.coerce.date(),
+  accountId: z.string(),
+  methodNotes: z.string().nullable().optional(),
+  recordedById: z.string().nullable().optional(),
+  recordedByName: z.string().nullable().optional(),
+});

--- a/server/src/modules/payment-accounts/index.ts
+++ b/server/src/modules/payment-accounts/index.ts
@@ -1,0 +1,1 @@
+export { default as paymentAccountRouter } from './paymentAccount.router';

--- a/server/src/modules/payment-accounts/paymentAccount.repository.ts
+++ b/server/src/modules/payment-accounts/paymentAccount.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const paymentAccountRepository = {
+  findAll: () =>
+    prisma.paymentAccount.findMany({
+      include: { payments: true, expenses: true },
+      orderBy: { name: 'asc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.paymentAccount.findUnique({
+      where: { id },
+      include: { payments: true, expenses: true },
+    }),
+
+  create: (data: Prisma.PaymentAccountCreateInput) =>
+    prisma.paymentAccount.create({ data, include: { payments: true, expenses: true } }),
+
+  update: (id: string, data: Prisma.PaymentAccountUpdateInput) =>
+    prisma.paymentAccount.update({
+      where: { id },
+      data,
+      include: { payments: true, expenses: true },
+    }),
+
+  delete: (id: string) => prisma.paymentAccount.delete({ where: { id } }),
+};

--- a/server/src/modules/payment-accounts/paymentAccount.router.ts
+++ b/server/src/modules/payment-accounts/paymentAccount.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { paymentAccountService } from './paymentAccount.service';
+import {
+  paymentAccountSchema,
+  paymentAccountUpdateSchema,
+} from './paymentAccount.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const accounts = await paymentAccountService.list();
+    res.json(accounts);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const account = await paymentAccountService.getById(req.params.id);
+    res.json(account);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = paymentAccountSchema.parse(req.body);
+    const account = await paymentAccountService.create(payload);
+    res.status(201).json(account);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = paymentAccountUpdateSchema.parse(req.body);
+    const account = await paymentAccountService.update(req.params.id, payload);
+    res.json(account);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await paymentAccountService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/payment-accounts/paymentAccount.service.ts
+++ b/server/src/modules/payment-accounts/paymentAccount.service.ts
@@ -1,0 +1,51 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { paymentAccountRepository } from './paymentAccount.repository';
+
+export interface PaymentAccountInput {
+  id?: string;
+  name: string;
+  type: string;
+  details?: string;
+}
+
+export const paymentAccountService = {
+  list() {
+    return paymentAccountRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const account = await paymentAccountRepository.findById(id);
+    if (!account) {
+      throw new createError.NotFound(`Payment account ${id} not found`);
+    }
+    return account;
+  },
+
+  create(payload: PaymentAccountInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.PaymentAccountCreateInput = {
+      id,
+      name: payload.name,
+      type: payload.type,
+      details: payload.details,
+    };
+    return paymentAccountRepository.create(data);
+  },
+
+  async update(id: string, payload: Partial<PaymentAccountInput>) {
+    await paymentAccountService.getById(id);
+    const data: Prisma.PaymentAccountUpdateInput = {
+      name: payload.name,
+      type: payload.type,
+      details: payload.details,
+    };
+    return paymentAccountRepository.update(id, data);
+  },
+
+  async remove(id: string) {
+    await paymentAccountService.getById(id);
+    await paymentAccountRepository.delete(id);
+  },
+};

--- a/server/src/modules/payment-accounts/paymentAccount.validation.ts
+++ b/server/src/modules/payment-accounts/paymentAccount.validation.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const paymentAccountSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  type: z.string().min(1),
+  details: z.string().optional(),
+});
+
+export const paymentAccountUpdateSchema = paymentAccountSchema.partial();

--- a/server/src/modules/session-categories/index.ts
+++ b/server/src/modules/session-categories/index.ts
@@ -1,0 +1,1 @@
+export { default as sessionCategoryRouter } from './sessionCategory.router';

--- a/server/src/modules/session-categories/sessionCategory.repository.ts
+++ b/server/src/modules/session-categories/sessionCategory.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const sessionCategoryRepository = {
+  findAll: () =>
+    prisma.sessionCategory.findMany({
+      include: { packages: true },
+      orderBy: { name: 'asc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.sessionCategory.findUnique({
+      where: { id },
+      include: { packages: true },
+    }),
+
+  create: (data: Prisma.SessionCategoryCreateInput) =>
+    prisma.sessionCategory.create({ data, include: { packages: true } }),
+
+  update: (id: string, data: Prisma.SessionCategoryUpdateInput) =>
+    prisma.sessionCategory.update({
+      where: { id },
+      data,
+      include: { packages: true },
+    }),
+
+  delete: (id: string) => prisma.sessionCategory.delete({ where: { id } }),
+};

--- a/server/src/modules/session-categories/sessionCategory.router.ts
+++ b/server/src/modules/session-categories/sessionCategory.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { sessionCategoryService } from './sessionCategory.service';
+import {
+  sessionCategorySchema,
+  sessionCategoryUpdateSchema,
+} from './sessionCategory.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const categories = await sessionCategoryService.list();
+    res.json(categories);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const category = await sessionCategoryService.getById(req.params.id);
+    res.json(category);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = sessionCategorySchema.parse(req.body);
+    const category = await sessionCategoryService.create(payload);
+    res.status(201).json(category);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = sessionCategoryUpdateSchema.parse(req.body);
+    const category = await sessionCategoryService.update(req.params.id, payload);
+    res.json(category);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await sessionCategoryService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/session-categories/sessionCategory.service.ts
+++ b/server/src/modules/session-categories/sessionCategory.service.ts
@@ -1,0 +1,82 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { sessionCategoryRepository } from './sessionCategory.repository';
+
+export interface SessionCategoryInput {
+  id?: string;
+  name: string;
+  packages?: Array<{
+    id?: string;
+    name: string;
+    price: number;
+    inclusions?: string[];
+  }>;
+}
+
+export const sessionCategoryService = {
+  list() {
+    return sessionCategoryRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const category = await sessionCategoryRepository.findById(id);
+    if (!category) {
+      throw new createError.NotFound(`Session category ${id} not found`);
+    }
+    return category;
+  },
+
+  create(payload: SessionCategoryInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.SessionCategoryCreateInput = {
+      id,
+      name: payload.name,
+      packages: payload.packages
+        ? {
+            create: payload.packages.map((pkg) => ({
+              id: pkg.id ?? randomUUID(),
+              name: pkg.name,
+              price: pkg.price,
+              inclusions: pkg.inclusions ?? [],
+            })),
+          }
+        : undefined,
+    };
+    return sessionCategoryRepository.create(data);
+  },
+
+  async update(id: string, payload: SessionCategoryInput) {
+    await sessionCategoryService.getById(id);
+    const data: Prisma.SessionCategoryUpdateInput = {
+      name: payload.name,
+      packages: payload.packages
+        ? {
+            upsert: payload.packages.map((pkg) => {
+              const idValue = pkg.id ?? randomUUID();
+              return {
+                where: { id: idValue },
+                update: {
+                  name: pkg.name,
+                  price: pkg.price,
+                  inclusions: pkg.inclusions ?? [],
+                },
+                create: {
+                  id: idValue,
+                  name: pkg.name,
+                  price: pkg.price,
+                  inclusions: pkg.inclusions ?? [],
+                },
+              };
+            }),
+          }
+        : undefined,
+    };
+    return sessionCategoryRepository.update(id, data);
+  },
+
+  async remove(id: string) {
+    await sessionCategoryService.getById(id);
+    await sessionCategoryRepository.delete(id);
+  },
+};

--- a/server/src/modules/session-categories/sessionCategory.validation.ts
+++ b/server/src/modules/session-categories/sessionCategory.validation.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+const packageSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  price: z.coerce.number().nonnegative(),
+  inclusions: z.array(z.string()).optional(),
+});
+
+export const sessionCategorySchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  packages: z.array(packageSchema).optional(),
+});
+
+export const sessionCategoryUpdateSchema = sessionCategorySchema.partial();

--- a/server/src/modules/session-packages/index.ts
+++ b/server/src/modules/session-packages/index.ts
@@ -1,0 +1,1 @@
+export { default as sessionPackageRouter } from './sessionPackage.router';

--- a/server/src/modules/session-packages/sessionPackage.repository.ts
+++ b/server/src/modules/session-packages/sessionPackage.repository.ts
@@ -1,0 +1,28 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const sessionPackageRepository = {
+  findAll: () =>
+    prisma.sessionPackage.findMany({
+      include: { category: true },
+      orderBy: { name: 'asc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.sessionPackage.findUnique({
+      where: { id },
+      include: { category: true },
+    }),
+
+  create: (data: Prisma.SessionPackageCreateInput) =>
+    prisma.sessionPackage.create({ data, include: { category: true } }),
+
+  update: (id: string, data: Prisma.SessionPackageUpdateInput) =>
+    prisma.sessionPackage.update({
+      where: { id },
+      data,
+      include: { category: true },
+    }),
+
+  delete: (id: string) => prisma.sessionPackage.delete({ where: { id } }),
+};

--- a/server/src/modules/session-packages/sessionPackage.router.ts
+++ b/server/src/modules/session-packages/sessionPackage.router.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+import { sessionPackageService } from './sessionPackage.service';
+import {
+  sessionPackageSchema,
+  sessionPackageUpdateSchema,
+} from './sessionPackage.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const packages = await sessionPackageService.list();
+    res.json(packages);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const pkg = await sessionPackageService.getById(req.params.id);
+    res.json(pkg);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = sessionPackageSchema.parse(req.body);
+    const pkg = await sessionPackageService.create(payload);
+    res.status(201).json(pkg);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = sessionPackageUpdateSchema.parse(req.body);
+    const pkg = await sessionPackageService.update(req.params.id, payload);
+    res.json(pkg);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await sessionPackageService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/session-packages/sessionPackage.service.ts
+++ b/server/src/modules/session-packages/sessionPackage.service.ts
@@ -1,0 +1,60 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { sessionPackageRepository } from './sessionPackage.repository';
+
+export interface SessionPackageInput {
+  id?: string;
+  categoryId: string;
+  name: string;
+  price: number;
+  inclusions?: string[];
+}
+
+export const sessionPackageService = {
+  list() {
+    return sessionPackageRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const pkg = await sessionPackageRepository.findById(id);
+    if (!pkg) {
+      throw new createError.NotFound(`Session package ${id} not found`);
+    }
+    return pkg;
+  },
+
+  create(payload: SessionPackageInput) {
+    const id = payload.id ?? randomUUID();
+    const data: Prisma.SessionPackageCreateInput = {
+      id,
+      name: payload.name,
+      price: payload.price,
+      inclusions: payload.inclusions ?? [],
+      category: {
+        connect: { id: payload.categoryId },
+      },
+    };
+    return sessionPackageRepository.create(data);
+  },
+
+  async update(id: string, payload: Partial<SessionPackageInput>) {
+    await sessionPackageService.getById(id);
+    const data: Prisma.SessionPackageUpdateInput = {
+      name: payload.name,
+      price: payload.price,
+      inclusions: payload.inclusions,
+      category: payload.categoryId
+        ? {
+            connect: { id: payload.categoryId },
+          }
+        : undefined,
+    };
+    return sessionPackageRepository.update(id, data);
+  },
+
+  async remove(id: string) {
+    await sessionPackageService.getById(id);
+    await sessionPackageRepository.delete(id);
+  },
+};

--- a/server/src/modules/session-packages/sessionPackage.validation.ts
+++ b/server/src/modules/session-packages/sessionPackage.validation.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const sessionPackageSchema = z.object({
+  id: z.string().optional(),
+  categoryId: z.string(),
+  name: z.string().min(1),
+  price: z.coerce.number().nonnegative(),
+  inclusions: z.array(z.string()).optional(),
+});
+
+export const sessionPackageUpdateSchema = sessionPackageSchema.partial();

--- a/server/src/modules/staff/index.ts
+++ b/server/src/modules/staff/index.ts
@@ -1,0 +1,1 @@
+export { default as staffRouter } from './staff.router';

--- a/server/src/modules/staff/staff.repository.ts
+++ b/server/src/modules/staff/staff.repository.ts
@@ -1,0 +1,25 @@
+import prisma from '../../lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export const staffRepository = {
+  findAll: () =>
+    prisma.staff.findMany({
+      orderBy: { name: 'asc' },
+    }),
+
+  findById: (id: string) =>
+    prisma.staff.findUnique({
+      where: { id },
+      include: {
+        photographerBookings: true,
+        editingJobs: true,
+      },
+    }),
+
+  create: (data: Prisma.StaffCreateInput) => prisma.staff.create({ data }),
+
+  update: (id: string, data: Prisma.StaffUpdateInput) =>
+    prisma.staff.update({ where: { id }, data }),
+
+  delete: (id: string) => prisma.staff.delete({ where: { id } }),
+};

--- a/server/src/modules/staff/staff.router.ts
+++ b/server/src/modules/staff/staff.router.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import { staffService } from './staff.service';
+import { createStaffSchema, updateStaffSchema } from './staff.validation';
+
+const router = Router();
+
+router.get('/', async (_req, res, next) => {
+  try {
+    const staff = await staffService.list();
+    res.json(staff);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/:id', async (req, res, next) => {
+  try {
+    const staff = await staffService.getById(req.params.id);
+    res.json(staff);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/', async (req, res, next) => {
+  try {
+    const payload = createStaffSchema.parse(req.body);
+    const staff = await staffService.create(payload);
+    res.status(201).json(staff);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/:id', async (req, res, next) => {
+  try {
+    const payload = updateStaffSchema.parse(req.body);
+    const staff = await staffService.update(req.params.id, payload);
+    res.json(staff);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await staffService.remove(req.params.id);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/modules/staff/staff.service.ts
+++ b/server/src/modules/staff/staff.service.ts
@@ -1,0 +1,36 @@
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import createError from 'http-errors';
+import { staffRepository } from './staff.repository';
+
+export const staffService = {
+  async list() {
+    return staffRepository.findAll();
+  },
+
+  async getById(id: string) {
+    const staff = await staffRepository.findById(id);
+    if (!staff) {
+      throw new createError.NotFound(`Staff ${id} not found`);
+    }
+    return staff;
+  },
+
+  async create(payload: Prisma.StaffCreateInput) {
+    const id = payload.id ?? randomUUID();
+    return staffRepository.create({
+      ...payload,
+      id,
+    });
+  },
+
+  async update(id: string, payload: Prisma.StaffUpdateInput) {
+    await staffService.getById(id);
+    return staffRepository.update(id, payload);
+  },
+
+  async remove(id: string) {
+    await staffService.getById(id);
+    await staffRepository.delete(id);
+  },
+};

--- a/server/src/modules/staff/staff.validation.ts
+++ b/server/src/modules/staff/staff.validation.ts
@@ -1,0 +1,15 @@
+import { StaffStatus, UserRole } from '@prisma/client';
+import { z } from 'zod';
+
+export const staffBaseSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().min(1),
+  email: z.string().email(),
+  avatarUrl: z.string().url().optional(),
+  role: z.nativeEnum(UserRole),
+  status: z.nativeEnum(StaffStatus),
+  lastLogin: z.coerce.date().optional(),
+});
+
+export const createStaffSchema = staffBaseSchema;
+export const updateStaffSchema = staffBaseSchema.partial();

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -1,0 +1,274 @@
+import 'dotenv/config';
+import { BookingStatus, InvoiceStatus, JobPriority, Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import prisma from './lib/prisma';
+import { clientRepository } from './modules/clients/client.repository';
+import {
+  mockBookings,
+  mockClients,
+  mockEditingJobs,
+  mockEditingStatuses,
+  mockExpenses,
+  mockInvoices,
+  mockPaymentAccounts,
+  mockSessionTypes,
+  mockStaff,
+} from '../../services/mockData';
+
+const priorityMap: Record<string, JobPriority> = {
+  low: JobPriority.Low,
+  normal: JobPriority.Normal,
+  high: JobPriority.High,
+  urgent: JobPriority.Urgent,
+};
+
+const bookingStatusMap: Record<string, BookingStatus> = {
+  pending: BookingStatus.Pending,
+  confirmed: BookingStatus.Confirmed,
+  completed: BookingStatus.Completed,
+  cancelled: BookingStatus.Cancelled,
+};
+
+const invoiceStatusMap: Record<string, InvoiceStatus> = {
+  paid: InvoiceStatus.Paid,
+  sent: InvoiceStatus.Sent,
+  overdue: InvoiceStatus.Overdue,
+};
+
+async function resetDatabase() {
+  await prisma.payment.deleteMany();
+  await prisma.invoiceItem.deleteMany();
+  await prisma.invoice.deleteMany();
+  await prisma.expense.deleteMany();
+  await prisma.editingJob.deleteMany();
+  await prisma.editingStatus.deleteMany();
+  await prisma.booking.deleteMany();
+  await prisma.sessionPackage.deleteMany();
+  await prisma.sessionCategory.deleteMany();
+  await prisma.paymentAccount.deleteMany();
+  await prisma.staff.deleteMany();
+  await prisma.client.deleteMany();
+}
+
+async function seedStaff() {
+  for (const staff of mockStaff) {
+    await prisma.staff.create({
+      data: {
+        id: staff.id,
+        name: staff.name,
+        email: staff.email,
+        avatarUrl: staff.avatarUrl,
+        role: staff.role,
+        status: staff.status,
+        lastLogin: staff.lastLogin ?? undefined,
+      },
+    });
+  }
+}
+
+async function seedClients() {
+  for (const client of mockClients) {
+    await prisma.client.create({
+      data: {
+        id: client.id,
+        name: client.name,
+        email: client.email,
+        phone: client.phone,
+        avatarUrl: client.avatarUrl,
+        joinDate: client.joinDate,
+        totalBookings: client.totalBookings ?? 0,
+        totalSpent: new Prisma.Decimal(client.totalSpent ?? 0),
+        notes: client.notes,
+        financialStatus: client.financialStatus,
+      },
+    });
+  }
+}
+
+async function seedEditingStatuses() {
+  for (const status of mockEditingStatuses) {
+    await prisma.editingStatus.create({
+      data: {
+        id: status.id,
+        name: status.name,
+        color: status.color,
+      },
+    });
+  }
+}
+
+async function seedSessionCategories() {
+  for (const category of mockSessionTypes) {
+    await prisma.sessionCategory.create({
+      data: {
+        id: category.id,
+        name: category.name,
+        packages: {
+          create: category.packages.map((pkg) => ({
+            id: pkg.id,
+            name: pkg.name,
+            price: pkg.price,
+            inclusions: pkg.inclusions ?? [],
+          })),
+        },
+      },
+    });
+  }
+}
+
+async function seedPaymentAccounts() {
+  for (const account of mockPaymentAccounts) {
+    await prisma.paymentAccount.create({
+      data: {
+        id: account.id,
+        name: account.name,
+        type: account.type,
+        details: account.details,
+      },
+    });
+  }
+}
+
+async function seedBookings() {
+  for (const booking of mockBookings) {
+    const status = bookingStatusMap[booking.status.toLowerCase()] ?? BookingStatus.Pending;
+    await prisma.booking.create({
+      data: {
+        id: booking.id,
+        client: { connect: { id: booking.clientId } },
+        clientName: booking.clientName,
+        clientAvatarUrl: booking.clientAvatarUrl,
+        sessionCategory: { connect: { id: booking.sessionCategoryId } },
+        sessionPackage: { connect: { id: booking.sessionPackageId } },
+        sessionType: booking.sessionType,
+        photographer: booking.photographerId ? { connect: { id: booking.photographerId } } : undefined,
+        photographerName: booking.photographer,
+        date: booking.date,
+        status,
+        notes: booking.notes,
+        location: booking.location,
+        photoSelections: booking.photoSelections ?? undefined,
+      },
+    });
+  }
+}
+
+async function seedInvoices() {
+  const staffByName = new Map(mockStaff.map((staff) => [staff.name, staff.id]));
+  for (const invoice of mockInvoices) {
+    const status = invoiceStatusMap[invoice.status.toLowerCase()] ?? InvoiceStatus.Sent;
+    const payments = invoice.payments ?? [];
+    const amountPaid = payments.reduce((sum, payment) => sum + payment.amount, 0);
+    await prisma.invoice.create({
+      data: {
+        id: invoice.id,
+        booking: invoice.bookingId !== '-' ? { connect: { id: invoice.bookingId } } : undefined,
+        client: { connect: { id: invoice.clientId } },
+        clientName: invoice.clientName,
+        clientAvatarUrl: invoice.clientAvatarUrl,
+        amount: invoice.amount,
+        amountPaid,
+        issueDate: invoice.issueDate ?? undefined,
+        dueDate: invoice.dueDate,
+        status,
+        lastReminderSent: invoice.lastReminderSent ?? undefined,
+        items: {
+          create: invoice.items.map((item) => ({
+            id: item.id ?? randomUUID(),
+            description: item.description,
+            quantity: item.quantity,
+            price: item.price,
+          })),
+        },
+        payments: {
+          create: payments.map((payment) => ({
+            id: payment.id ?? randomUUID(),
+            amount: payment.amount,
+            date: payment.date,
+            account: { connect: { id: payment.accountId } },
+            methodNotes: payment.methodNotes ?? undefined,
+            recordedByName: payment.recordedBy ?? undefined,
+            recordedBy: payment.recordedBy && staffByName.get(payment.recordedBy)
+              ? { connect: { id: staffByName.get(payment.recordedBy)! } }
+              : undefined,
+          })),
+        },
+      },
+    });
+  }
+}
+
+async function seedEditingJobs() {
+  for (const job of mockEditingJobs) {
+    const priority = priorityMap[job.priority?.toLowerCase?.() ?? 'normal'] ?? JobPriority.Normal;
+    await prisma.editingJob.create({
+      data: {
+        id: job.id,
+        booking: { connect: { id: job.bookingId } },
+        client: { connect: { id: job.clientId } },
+        clientName: job.clientName,
+        editor: job.editorId ? { connect: { id: job.editorId } } : undefined,
+        editorName: job.editorName ?? undefined,
+        editorAvatarUrl: job.editorAvatarUrl ?? undefined,
+        status: { connect: { id: job.statusId } },
+        uploadDate: job.uploadDate,
+        driveFolderUrl: job.driveFolderUrl ?? undefined,
+        photographerNotes: job.photographerNotes ?? undefined,
+        priority,
+        revisionCount: job.revisionCount ?? 0,
+        revisionNotes: job.revisionNotes ?? undefined,
+      },
+    });
+  }
+}
+
+async function seedExpenses() {
+  for (const expense of mockExpenses) {
+    await prisma.expense.create({
+      data: {
+        id: expense.id,
+        category: expense.category,
+        description: expense.description,
+        amount: expense.amount,
+        date: expense.date,
+        account: { connect: { id: expense.accountId } },
+        booking: expense.bookingId ? { connect: { id: expense.bookingId } } : undefined,
+      },
+    });
+  }
+}
+
+async function refreshClientStats() {
+  const clients = await prisma.client.findMany({ select: { id: true } });
+  for (const client of clients) {
+    await clientRepository.updateStats(client.id);
+  }
+}
+
+async function main() {
+  await resetDatabase();
+  await seedStaff();
+  await seedClients();
+  await seedEditingStatuses();
+  await seedSessionCategories();
+  await seedPaymentAccounts();
+  await seedBookings();
+  await seedInvoices();
+  await seedEditingJobs();
+  await seedExpenses();
+  await refreshClientStats();
+}
+
+main()
+  .then(() => {
+    // eslint-disable-next-line no-console
+    console.log('Database seeded successfully');
+  })
+  .catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Seeding failed', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,12 @@
+import dotenv from 'dotenv';
+import { createApp } from './app';
+
+dotenv.config();
+
+const app = createApp();
+const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 4000;
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "types": ["node"],
+    "baseUrl": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript/Express backend under `server/` with environment configuration and a Prisma schema modeling clients, bookings, invoices, editing jobs, expenses, and related tables
- implement repository/service/router layers for all major entities with validation, business rules (automatic editing job creation, client statistics refresh, payment handling), and REST endpoints
- add a seeding script that hydrates PostgreSQL from the shared mock data and document backend setup in the README

## Testing
- `npm install` *(fails: npm registry responded 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6593a08ec832b90fedd4db5b44db0